### PR TITLE
Nits from Brian

### DIFF
--- a/draft-ietf-iasa2-rfc2031bis.xml
+++ b/draft-ietf-iasa2-rfc2031bis.xml
@@ -119,9 +119,9 @@ target="RFC4071"/> and <xref target="RFC4371"/>.
 
   <t>
 In 2018, the IASA was revised under a new "IASA 2.0" structure by the
-IASA2 Working Group, which made signifincant revisions to the IETF's
+IASA2 Working Group, which made significant revisions to the IETF's
 administrative, legal, and financial structure. One critical outcome
-was that the formation, in close cooperation between the IETF and
+was the formation, in close cooperation between the IETF and
 ISOC, of the IETF Administration Limited Liability Company (IETF LLC)
 as a subsidiary of ISOC.
   </t>
@@ -310,19 +310,21 @@ target="I-D.ietf-iasa2-rfc4071bis"/>.
 
 </section>	
 
+<section title="IANA Considerations">
 
+	<t>This document introduces no new IANA considerations.</t>
+
+</section>
 
 <section title="Security Considerations">
 
 	<t>This document introduces no new security considerations.</t>
-	<t>[RFC Editor: Please remove this section upon publication.]</t>
 
 </section>
 	
 <section title="Privacy Considerations">
 
 	<t>This document introduces no new privacy considerations.</t>
-	<t>[RFC Editor: Please remove this section upon publication.]</t>
 
 </section>
 	  
@@ -339,6 +341,8 @@ replaces.
 <section anchor="changes" title="Changes from Previous Versions">
 	<t>RFC Editor: Please remove this section upon publication.</t>
 	<t>-00: Initial version published</t>
+	<t>-01: Several key updates to prepare WGLC based on WG feedback</t>
+	<t>-02: Fixed nits identified by Brian Carpenter on 12-21-2018</t>
 </section>
 
 </middle>


### PR DESCRIPTION
The draft seems fine to me.

Nits:

    In 2018, the IASA was revised under a new "IASA 2.0" structure by the
    IASA2 Working Group, which made signifincant revisions to the IETF's
s/signifincant/significant/
    administrative, legal, and financial structure.  One critical outcome
    was that the formation, in close cooperation between the IETF and
s/that//
    ISOC, of the IETF Administration Limited Liability Company (IETF LLC)
    as a subsidiary of ISOC.

...

8.  Security Considerations
    This document introduces no new security considerations.
    [RFC Editor: Please remove this section upon publication.]
9.  Privacy Considerations
    This document introduces no new privacy considerations.
    [RFC Editor: Please remove this section upon publication.]

No, we don't remove those sections when they're blank. And in theory,
a blank IANA Considerations section is also needed.

Regards
   Brian Carpenter